### PR TITLE
Instructions script attribute should run from anchor context working directory

### DIFF
--- a/cmd/anchor/main.go
+++ b/cmd/anchor/main.go
@@ -101,7 +101,7 @@ func initConfiguration(ctx common.Context, cfgManager config.ConfigManager, shou
 func initRegistry(ctx common.Context) error {
 	reg := ctx.Registry()
 
-	s := shell.New()
+	s := shell.New(ctx)
 	reg.Set(shell.Identifier, s)
 
 	e := extractor.New()

--- a/internal/cmd/anchor/dynamic/runner/runner.go
+++ b/internal/cmd/anchor/dynamic/runner/runner.go
@@ -174,7 +174,6 @@ func executeInstructionAction(o *ActionRunnerOrchestrator, action *models.Action
 		filePath, args := extractArgsFromScriptFile(action.ScriptFile)
 		spnr.Spin()
 		if err := o.s.ExecuteScriptFileSilentlyWithOutputToFile(
-			action.AnchorfilesRepoPath,
 			filePath,
 			scriptOutputPath,
 			args...); err != nil {
@@ -202,7 +201,6 @@ func executeInstructionActionVerbose(o *ActionRunnerOrchestrator, action *models
 		filePath, args := extractArgsFromScriptFile(action.ScriptFile)
 		plainer.Start()
 		if err := o.s.ExecuteScriptFileWithOutputToFile(
-			action.AnchorfilesRepoPath,
 			filePath,
 			scriptOutputPath,
 			args...); err != nil {

--- a/internal/cmd/anchor/dynamic/runner/runner_test.go
+++ b/internal/cmd/anchor/dynamic/runner/runner_test.go
@@ -293,7 +293,7 @@ var ActionExecFailToExecScriptFile = func(t *testing.T) {
 			}
 
 			execCallCount := 0
-			fakeShell.ExecuteScriptFileSilentlyWithOutputToFileMock = func(workingDirectory string, relativeScriptPath string, outputFilePath string, args ...string) error {
+			fakeShell.ExecuteScriptFileSilentlyWithOutputToFileMock = func(relativeScriptPath string, outputFilePath string, args ...string) error {
 				execCallCount++
 				assert.Equal(t, "/path/to/script", relativeScriptPath)
 				return fmt.Errorf("fail to execute")
@@ -307,7 +307,7 @@ var ActionExecFailToExecScriptFile = func(t *testing.T) {
 			fakeO.prntr = fakePrinter
 
 			err := executeInstructionAction(fakeO, action1, "")
-			assert.NotNil(t, err, "expected  to fail")
+			assert.NotNil(t, err, "expected to fail")
 			assert.Equal(t, 1, spinCallCount, "expected to be called exactly once")
 			assert.Equal(t, 1, execCallCount, "expected to be called exactly once")
 			assert.Equal(t, 1, stopOnFailureCallCount, "expected to be called exactly once")
@@ -339,7 +339,7 @@ var ActionExecExecScriptFileSuccessfully = func(t *testing.T) {
 			}
 
 			execCallCount := 0
-			fakeShell.ExecuteScriptFileSilentlyWithOutputToFileMock = func(workingDirectory string, relativeScriptPath string, outputFilePath string, args ...string) error {
+			fakeShell.ExecuteScriptFileSilentlyWithOutputToFileMock = func(relativeScriptPath string, outputFilePath string, args ...string) error {
 				execCallCount++
 				assert.Equal(t, "/path/to/script", relativeScriptPath)
 				return nil
@@ -508,7 +508,7 @@ var ActionExecVerboseFailToExecScriptFile = func(t *testing.T) {
 			}
 
 			execCallCount := 0
-			fakeShell.ExecuteScriptFileWithOutputToFileMock = func(workingDirectory string, relativeScriptPath string, outputFilePath string, args ...string) error {
+			fakeShell.ExecuteScriptFileWithOutputToFileMock = func(relativeScriptPath string, outputFilePath string, args ...string) error {
 				execCallCount++
 				assert.Equal(t, "/path/to/script", relativeScriptPath)
 				return fmt.Errorf("fail to execute")
@@ -554,7 +554,7 @@ var ActionExecVerboseExecScriptFileSuccessfully = func(t *testing.T) {
 			}
 
 			execCallCount := 0
-			fakeShell.ExecuteScriptFileWithOutputToFileMock = func(workingDirectory string, relativeScriptPath string, outputFilePath string, args ...string) error {
+			fakeShell.ExecuteScriptFileWithOutputToFileMock = func(relativeScriptPath string, outputFilePath string, args ...string) error {
 				execCallCount++
 				assert.Equal(t, "/path/to/script", relativeScriptPath)
 				return nil

--- a/pkg/utils/shell/shell_fakes.go
+++ b/pkg/utils/shell/shell_fakes.go
@@ -10,9 +10,9 @@ type fakeShell struct {
 	ExecuteWithOutputToFileMock                   func(script string, outputFilePath string) error
 	ExecuteSilentlyWithOutputToFileMock           func(script string, outputFilePath string) error
 	ExecuteSilentlyMock                           func(script string) error
-	ExecuteScriptFileMock                         func(dir string, relativeScriptPath string, args ...string) error
-	ExecuteScriptFileWithOutputToFileMock         func(dir string, relativeScriptPath string, outputFilePath string, args ...string) error
-	ExecuteScriptFileSilentlyWithOutputToFileMock func(workingDirectory string, relativeScriptPath string, outputFilePath string, args ...string) error
+	ExecuteScriptFileMock                         func(relativeScriptPath string, args ...string) error
+	ExecuteScriptFileWithOutputToFileMock         func(relativeScriptPath string, outputFilePath string, args ...string) error
+	ExecuteScriptFileSilentlyWithOutputToFileMock func(relativeScriptPath string, outputFilePath string, args ...string) error
 	ExecuteReturnOutputMock                       func(script string) (string, error)
 	ExecuteTTYMock                                func(script string) error
 	ExecuteInBackgroundMock                       func(script string) error
@@ -35,26 +35,24 @@ func (s *fakeShell) ExecuteSilently(script string) error {
 	return s.ExecuteSilentlyMock(script)
 }
 
-func (s *fakeShell) ExecuteScriptFile(dir string, relativeScriptPath string, args ...string) error {
-	return s.ExecuteScriptFileMock(dir, relativeScriptPath, args...)
+func (s *fakeShell) ExecuteScriptFile(relativeScriptPath string, args ...string) error {
+	return s.ExecuteScriptFileMock(relativeScriptPath, args...)
 }
 
 func (s *fakeShell) ExecuteScriptFileWithOutputToFile(
-	workingDirectory string,
 	relativeScriptPath string,
 	outputFilePath string,
 	args ...string) error {
 
-	return s.ExecuteScriptFileWithOutputToFileMock(workingDirectory, relativeScriptPath, outputFilePath, args...)
+	return s.ExecuteScriptFileWithOutputToFileMock(relativeScriptPath, outputFilePath, args...)
 }
 
 func (s *fakeShell) ExecuteScriptFileSilentlyWithOutputToFile(
-	workingDirectory string,
 	relativeScriptPath string,
 	outputFilePath string,
 	args ...string) error {
 
-	return s.ExecuteScriptFileSilentlyWithOutputToFileMock(workingDirectory, relativeScriptPath, outputFilePath, args...)
+	return s.ExecuteScriptFileSilentlyWithOutputToFileMock(relativeScriptPath, outputFilePath, args...)
 }
 
 func (s *fakeShell) ExecuteReturnOutput(script string) (string, error) {


### PR DESCRIPTION
[src] Every shell script exec (file or direct) should use the current anchor context working directory
[src] Added run context to shell utility to prevent from passing the working directory