### PR TITLE
Shell scripts and git actions allows env vars substitution before execution

### DIFF
--- a/internal/repository/remote/remote_test.go
+++ b/internal/repository/remote/remote_test.go
@@ -312,7 +312,7 @@ var ResetToRevisionOnFirstTrySuccessfully = func(t *testing.T) {
 				remote.git = fakeGit
 				remote.prntr = fakePrinter
 
-				err := remote.resetToRevisionFunc(remote, remoteCfg.ClonePath, remoteCfg.Branch, remoteCfg.Revision)
+				err := remote.resetToRevisionFunc(remote, remoteCfg.Url, remoteCfg.ClonePath, remoteCfg.Branch, remoteCfg.Revision)
 				assert.Nil(t, err, "expected not to fail")
 				assert.Equal(t, 1, gitResetCallCount)
 				assert.Equal(t, 1, printSuccessCallCount)
@@ -335,7 +335,7 @@ var FailToFetchAfterFirstTryToResetFails = func(t *testing.T) {
 					return fmt.Errorf("fail to reset to revision 1st try")
 				}
 				gitFetchCallCount := 0
-				fakeGit.FetchShallowMock = func(path string, branch string) error {
+				fakeGit.FetchShallowMock = func(path string, url string, branch string) error {
 					gitFetchCallCount++
 					return fmt.Errorf("fail to fetch")
 				}
@@ -359,7 +359,7 @@ var FailToFetchAfterFirstTryToResetFails = func(t *testing.T) {
 				remote.git = fakeGit
 				remote.prntr = fakePrinter
 
-				err := remote.resetToRevisionFunc(remote, remoteCfg.ClonePath, remoteCfg.Branch, remoteCfg.Revision)
+				err := remote.resetToRevisionFunc(remote, remoteCfg.Url, remoteCfg.ClonePath, remoteCfg.Branch, remoteCfg.Revision)
 				assert.NotNil(t, err, "expected to fail")
 				assert.Equal(t, "fail to fetch", err.Error())
 				assert.Equal(t, 1, gitResetCallCount)
@@ -388,7 +388,7 @@ var ResetToRevisionOnSecondTrySuccessfully = func(t *testing.T) {
 					return nil
 				}
 				gitFetchCallCount := 0
-				fakeGit.FetchShallowMock = func(path string, branch string) error {
+				fakeGit.FetchShallowMock = func(path string, url string, branch string) error {
 					gitFetchCallCount++
 					return nil
 				}
@@ -412,7 +412,7 @@ var ResetToRevisionOnSecondTrySuccessfully = func(t *testing.T) {
 				remote.git = fakeGit
 				remote.prntr = fakePrinter
 
-				err := remote.resetToRevisionFunc(remote, remoteCfg.ClonePath, remoteCfg.Branch, remoteCfg.Revision)
+				err := remote.resetToRevisionFunc(remote, remoteCfg.Url, remoteCfg.ClonePath, remoteCfg.Branch, remoteCfg.Revision)
 				assert.Nil(t, err, "expected to succeed")
 				assert.Equal(t, 2, gitResetCallCount)
 				assert.Equal(t, 1, gitFetchCallCount)
@@ -440,7 +440,7 @@ var FailToResetToRevisionOnSecondTry = func(t *testing.T) {
 					return fmt.Errorf("fail to reset to revision 2nd try")
 				}
 				gitFetchCallCount := 0
-				fakeGit.FetchShallowMock = func(path string, branch string) error {
+				fakeGit.FetchShallowMock = func(path string, url string, branch string) error {
 					gitFetchCallCount++
 					return nil
 				}
@@ -464,7 +464,7 @@ var FailToResetToRevisionOnSecondTry = func(t *testing.T) {
 				remote.git = fakeGit
 				remote.prntr = fakePrinter
 
-				err := remote.resetToRevisionFunc(remote, remoteCfg.ClonePath, remoteCfg.Branch, remoteCfg.Revision)
+				err := remote.resetToRevisionFunc(remote, remoteCfg.Url, remoteCfg.ClonePath, remoteCfg.Branch, remoteCfg.Revision)
 				assert.NotNil(t, err, "expected to fail")
 				assert.Equal(t, "fail to reset to revision 2nd try", err.Error())
 				assert.Equal(t, 2, gitResetCallCount)
@@ -559,7 +559,7 @@ var AutoUpdateFailToResetToRevision = func(t *testing.T) {
 				}
 
 				resetToRevisionCallCount := 0
-				remote.resetToRevisionFunc = func(rr *remoteRepositoryImpl, clonePath string, branch string, revision string) error {
+				remote.resetToRevisionFunc = func(rr *remoteRepositoryImpl, url string, clonePath string, branch string, revision string) error {
 					resetToRevisionCallCount++
 					return fmt.Errorf("fail to reset to revision")
 				}
@@ -622,7 +622,7 @@ var AutoUpdateDoNotFailWhenRevisionDiffPrintFails = func(t *testing.T) {
 				remote.prntr = fakePrinter
 
 				resetToRevisionCallCount := 0
-				remote.resetToRevisionFunc = func(rr *remoteRepositoryImpl, clonePath string, branch string, revision string) error {
+				remote.resetToRevisionFunc = func(rr *remoteRepositoryImpl, url string, clonePath string, branch string, revision string) error {
 					resetToRevisionCallCount++
 					return nil
 				}
@@ -672,7 +672,7 @@ var AutoUpdateRunSuccessfulAlreadyUpToDateFlow = func(t *testing.T) {
 				}
 
 				resetToRevisionCallCount := 0
-				remote.resetToRevisionFunc = func(rr *remoteRepositoryImpl, clonePath string, branch string, revision string) error {
+				remote.resetToRevisionFunc = func(rr *remoteRepositoryImpl, url string, clonePath string, branch string, revision string) error {
 					resetToRevisionCallCount++
 					return nil
 				}
@@ -890,7 +890,7 @@ var LoadFailToResetToRevision = func(t *testing.T) {
 					return nil
 				}
 				resetToRevisionCallCount := 0
-				remote.resetToRevisionFunc = func(rr *remoteRepositoryImpl, clonePath string, branch string, revision string) error {
+				remote.resetToRevisionFunc = func(rr *remoteRepositoryImpl, url string, clonePath string, branch string, revision string) error {
 					resetToRevisionCallCount++
 					return fmt.Errorf("failed to reset to revision")
 				}
@@ -1083,7 +1083,7 @@ var LoadResetToRevisionAndWarnOnAutoUpdateEnabled = func(t *testing.T) {
 					return nil
 				}
 				resetToRevCallCount := 0
-				remote.resetToRevisionFunc = func(rr *remoteRepositoryImpl, clonePath string, branch string, revision string) error {
+				remote.resetToRevisionFunc = func(rr *remoteRepositoryImpl, url string, clonePath string, branch string, revision string) error {
 					resetToRevCallCount++
 					return nil
 				}

--- a/pkg/git/git_fakes.go
+++ b/pkg/git/git_fakes.go
@@ -9,7 +9,7 @@ type fakeGitImpl struct {
 	CloneMock                    func(url string, branch string, clonePath string) error
 	InitMock                     func(path string) error
 	AddOriginMock                func(path string, url string) error
-	FetchShallowMock             func(path string, branch string) error
+	FetchShallowMock             func(path string, url string, branch string) error
 	ResetMock                    func(path string, revision string) error
 	CheckoutMock                 func(path string, branch string) error
 	CleanMock                    func(path string) error
@@ -30,8 +30,8 @@ func (g *fakeGitImpl) AddOrigin(path string, url string) error {
 	return g.AddOriginMock(path, url)
 }
 
-func (g *fakeGitImpl) FetchShallow(path string, branch string) error {
-	return g.FetchShallowMock(path, branch)
+func (g *fakeGitImpl) FetchShallow(path string, url string, branch string) error {
+	return g.FetchShallowMock(path, url, branch)
 }
 
 func (g *fakeGitImpl) Reset(path string, revision string) error {

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -28,6 +28,10 @@ func Test_GitShould(t *testing.T) {
 			Func: FetchShallowSuccessfully,
 		},
 		{
+			Name: "fetch shallow using HTTPS successfully",
+			Func: FetchShallowUsingHttpsSuccessfully,
+		},
+		{
 			Name: "reset successfully",
 			Func: ResetSuccessfully,
 		},
@@ -112,6 +116,7 @@ var FetchShallowSuccessfully = func(t *testing.T) {
 		with.Logging(ctx, t, func(logger logger.Logger) {
 			clonePath := "/some/path"
 			branch := "my-branch"
+			url := "/some/url"
 			fakeShell := shell.CreateFakeShell()
 			fakeShell.ExecuteSilentlyMock = func(script string) error {
 				expected := fmt.Sprintf(`git -C %s fetch --shallow-since="4 weeks ago" --force origin refs/heads/%s:refs/remotes/origin/%s`, clonePath, branch, branch)
@@ -119,7 +124,25 @@ var FetchShallowSuccessfully = func(t *testing.T) {
 				return nil
 			}
 			git := New(fakeShell)
-			_ = git.FetchShallow(clonePath, branch)
+			_ = git.FetchShallow(clonePath, url, branch)
+		})
+	})
+}
+
+var FetchShallowUsingHttpsSuccessfully = func(t *testing.T) {
+	with.Context(func(ctx common.Context) {
+		with.Logging(ctx, t, func(logger logger.Logger) {
+			clonePath := "/some/path"
+			branch := "my-branch"
+			url := "https://\\${TOKEN}:@github.com/ORG/REPO.git"
+			fakeShell := shell.CreateFakeShell()
+			fakeShell.ExecuteSilentlyMock = func(script string) error {
+				expected := fmt.Sprintf(`git -C %s fetch --depth 1 --force origin refs/heads/%s:refs/remotes/origin/%s`, clonePath, branch, branch)
+				assert.Equal(t, expected, script)
+				return nil
+			}
+			git := New(fakeShell)
+			_ = git.FetchShallow(clonePath, url, branch)
 		})
 	})
 }

--- a/pkg/utils/shell/shell.go
+++ b/pkg/utils/shell/shell.go
@@ -158,7 +158,8 @@ func (s *shellExecutor) ExecuteScriptFileSilentlyWithOutputToFile(
 
 func (s *shellExecutor) Execute(script string) error {
 	workingDirectory := s.ctx.AnchorFilesPath()
-	cmd := exec.Command(string(s.shellType), "-c", script)
+	substituteEnvVarScript := expandScriptEnvVars(script)
+	cmd := exec.Command(string(s.shellType), "-c", substituteEnvVarScript)
 	cmd.Dir = workingDirectory
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -174,7 +175,8 @@ func (s *shellExecutor) Execute(script string) error {
 
 func (s *shellExecutor) ExecuteWithOutputToFile(script string, outputFilePath string) error {
 	workingDirectory := s.ctx.AnchorFilesPath()
-	cmd := exec.Command(string(s.shellType), "-c", script)
+	substituteEnvVarScript := expandScriptEnvVars(script)
+	cmd := exec.Command(string(s.shellType), "-c", substituteEnvVarScript)
 	cmd.Dir = workingDirectory
 
 	file, err := ioutils.CreateOrOpenFile(outputFilePath)
@@ -197,7 +199,8 @@ func (s *shellExecutor) ExecuteWithOutputToFile(script string, outputFilePath st
 
 func (s *shellExecutor) ExecuteSilentlyWithOutputToFile(script string, outputFilePath string) error {
 	workingDirectory := s.ctx.AnchorFilesPath()
-	cmd := exec.Command(string(s.shellType), "-c", script)
+	substituteEnvVarScript := expandScriptEnvVars(script)
+	cmd := exec.Command(string(s.shellType), "-c", substituteEnvVarScript)
 	cmd.Dir = workingDirectory
 
 	file, err := ioutils.CreateOrOpenFile(outputFilePath)
@@ -220,7 +223,8 @@ func (s *shellExecutor) ExecuteSilentlyWithOutputToFile(script string, outputFil
 // ExecuteTTY example was inspired by - https://github.com/creack/pty#shell
 func (s *shellExecutor) ExecuteTTY(script string) error {
 	workingDirectory := s.ctx.AnchorFilesPath()
-	c := exec.Command(string(s.shellType), "-c", script)
+	substituteEnvVarScript := expandScriptEnvVars(script)
+	c := exec.Command(string(s.shellType), "-c", substituteEnvVarScript)
 	c.Dir = workingDirectory
 
 	// Start the command with a pty
@@ -261,7 +265,8 @@ func (s *shellExecutor) ExecuteTTY(script string) error {
 
 func (s *shellExecutor) ExecuteReturnOutput(script string) (string, error) {
 	workingDirectory := s.ctx.AnchorFilesPath()
-	cmd := exec.Command(string(s.shellType), "-c", script)
+	substituteEnvVarScript := expandScriptEnvVars(script)
+	cmd := exec.Command(string(s.shellType), "-c", substituteEnvVarScript)
 	cmd.Dir = workingDirectory
 
 	var output string
@@ -279,7 +284,8 @@ func (s *shellExecutor) ExecuteReturnOutput(script string) (string, error) {
 
 func (s *shellExecutor) ExecuteSilently(script string) error {
 	workingDirectory := s.ctx.AnchorFilesPath()
-	cmd := exec.Command(string(s.shellType), "-c", script)
+	substituteEnvVarScript := expandScriptEnvVars(script)
+	cmd := exec.Command(string(s.shellType), "-c", substituteEnvVarScript)
 	cmd.Dir = workingDirectory
 
 	var _, stderrBuf bytes.Buffer
@@ -294,7 +300,8 @@ func (s *shellExecutor) ExecuteSilently(script string) error {
 
 func (s *shellExecutor) ExecuteInBackground(script string) error {
 	workingDirectory := s.ctx.AnchorFilesPath()
-	cmd := exec.Command(string(s.shellType), "-c", script)
+	substituteEnvVarScript := expandScriptEnvVars(script)
+	cmd := exec.Command(string(s.shellType), "-c", substituteEnvVarScript)
 	cmd.Dir = workingDirectory
 	// Temporary prevent logs verbosity from background process
 	//cmd.Stdout = os.Stdout
@@ -324,4 +331,8 @@ func extractLastErrorLine(errStr string) string {
 		return split[1]
 	}
 	return errStr
+}
+
+func expandScriptEnvVars(script string) string {
+	return os.ExpandEnv(script)
 }


### PR DESCRIPTION
[src] Git command allow env vars to get replaced before command run such as `GIT_ACCESS_TOKEN` substitution
[src] Added env vars substitution support to shell scripts before execution