### PR TITLE
Introduced a `--no-anchor-output` flag for `run` command that allows to hide anchor CLI output, show only script output

### DIFF
--- a/cmd/anchor/main.go
+++ b/cmd/anchor/main.go
@@ -25,7 +25,7 @@ var excludedCommandsFromPreRunSequence = []string{"config", "version", "completi
 // Keep nonCmdScopedFlags sorted in ascending order to keep using a binary search
 // These flag are being resolved before the cobra root command executes and are relevant to flows that aren't
 // command specific such as remote repository loading phase to get the actual dynamic CLI structure.
-var nonCmdScopedFlags = []string{globals.NoAutoUpdateFlagName}
+var nonCmdScopedFlags = []string{globals.NoAnchorOutputFlagName, globals.NoAutoUpdateFlagName}
 
 type MainCollaborators struct {
 	Logger           func(ctx common.Context, loggerManager logger.LoggerManager) error
@@ -122,7 +122,7 @@ func initRegistry(ctx common.Context) error {
 	pr := prompter.New()
 	reg.Set(prompter.Identifier, pr)
 
-	prntr := printer.New()
+	prntr := printer.New(ctx.NonCmdScopedFlags().NoAnchorOutput)
 	reg.Set(printer.Identifier, prntr)
 
 	in := input.New()
@@ -179,8 +179,11 @@ func extractNonCmdScopedFlags(args []string) common.NonCmdScopedFlags {
 		for _, arg := range args {
 			i := sort.SearchStrings(nonCmdScopedFlags, arg)
 			if i < len(nonCmdScopedFlags) { // means that the string index exists within the array
-				if arg == globals.NoAutoUpdateFlagName {
+				switch arg {
+				case globals.NoAutoUpdateFlagName:
 					result.NoAutoUpdate = true
+				case globals.NoAnchorOutputFlagName:
+					result.NoAnchorOutput = true
 				}
 			}
 		}

--- a/cmd/anchor/main_test.go
+++ b/cmd/anchor/main_test.go
@@ -624,8 +624,15 @@ var ExtractNonCommandFlagsFromProgramArguments = func(t *testing.T) {
 	assert.NotNil(t, flags)
 	assert.False(t, flags.NoAutoUpdate)
 
-	args = []string{"/cmd/path", "hide", "the", globals.NoAutoUpdateFlagName, "flag"}
+	args = []string{"/cmd/path", "skip", "auto", globals.NoAutoUpdateFlagName, "update"}
 	flags = extractNonCmdScopedFlags(args)
 	assert.NotNil(t, flags)
 	assert.True(t, flags.NoAutoUpdate)
+	assert.False(t, flags.NoAnchorOutput)
+
+	args = []string{"/cmd/path", "hide", "anchor", globals.NoAnchorOutputFlagName, "output"}
+	flags = extractNonCmdScopedFlags(args)
+	assert.NotNil(t, flags)
+	assert.True(t, flags.NoAnchorOutput)
+	assert.False(t, flags.NoAutoUpdate)
 }

--- a/internal/cmd/anchor/anchor_cmd.go
+++ b/internal/cmd/anchor/anchor_cmd.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ZachiNachshon/anchor/internal/globals"
 	"github.com/ZachiNachshon/anchor/internal/logger"
 	"github.com/spf13/cobra"
+	"strings"
 )
 
 func RunCliRootCommand(ctx common.Context, shouldStartPreRunSeq bool) error {
@@ -90,9 +91,9 @@ func initFlags(c *anchorCmd) error {
 	// This flag is defined in here to allow the user to see it when using --help
 	c.cobraCmd.PersistentFlags().BoolVar(
 		&noAutoUpdateFlagValue,
-		globals.NoAutoUpdateFlagName,
+		strings.TrimPrefix(globals.NoAutoUpdateFlagName, "--"),
 		noAutoUpdateFlagValue,
-		fmt.Sprintf("anchor <command> --%s", globals.NoAutoUpdateFlagName))
+		fmt.Sprintf("anchor <command> %s", globals.NoAutoUpdateFlagName))
 
 	c.cobraCmd.PersistentFlags().SortFlags = false
 	return nil

--- a/internal/cmd/anchor/dynamic/run/run.go
+++ b/internal/cmd/anchor/dynamic/run/run.go
@@ -30,8 +30,6 @@ var DynamicRun = func(ctx common.Context, o *runOrchestrator, identifier string)
 }
 
 type runOrchestrator struct {
-	verboseFlag bool
-
 	commandFolderName     string
 	commandFolderItemName string
 
@@ -55,11 +53,11 @@ func NewOrchestrator(
 	return &runOrchestrator{
 		commandFolderName:     commandFolderName,
 		commandFolderItemName: commandItemName,
-		verboseFlag:           false,
 		runner:                runner,
 
 		activeRunFunc: func(o *runOrchestrator, ctx common.Context, cmdFolderItem *models.CommandFolderItemInfo, identifier string) error {
-			// no-op, shouldn't happen since action/workflow must be used as they are mutually exclusive mandatory flags
+			// no-op, shouldn't happen since either action or workflow execution flow should set te relevant runner function,
+			// they are mutually exclusive mandatory flags so only a single active runner function should be set to run,
 			// check tests for additional info
 			return nil
 		},

--- a/internal/cmd/anchor/dynamic/run/run_cmd_test.go
+++ b/internal/cmd/anchor/dynamic/run/run_cmd_test.go
@@ -182,7 +182,7 @@ var RunInVerboseModeIfVerboseFlagSupplied = func(t *testing.T) {
 				callCount := 0
 				var fun = func(ctx common.Context, o *runOrchestrator, identifier string) error {
 					callCount++
-					assert.True(t, o.verboseFlag, "expected verbose flag to exist")
+					assert.True(t, o.runner.VerboseFlag, "expected verbose flag to exist")
 					return nil
 				}
 				command := NewCommand(ctx, stubs.CommandFolder1Name, fun)

--- a/internal/cmd/anchor/dynamic/runner/runner.go
+++ b/internal/cmd/anchor/dynamic/runner/runner.go
@@ -17,7 +17,7 @@ import (
 
 type ActionRunnerOrchestrator struct {
 	commandFolderName string
-	verboseFlag       bool
+	VerboseFlag       bool
 
 	e     extractor.Extractor
 	prsr  parser.Parser
@@ -55,7 +55,7 @@ type ActionRunnerOrchestrator struct {
 func NewOrchestrator(commandFolderName string) *ActionRunnerOrchestrator {
 	return &ActionRunnerOrchestrator{
 		commandFolderName: commandFolderName,
-		verboseFlag:       false,
+		VerboseFlag:       false,
 
 		// --- Internal ---
 		PrepareFunc: prepare,
@@ -170,7 +170,7 @@ func runInstructionAction(o *ActionRunnerOrchestrator, action *models.Action) *e
 		return errors.NewSchemaError(fmt.Errorf("missing script or scriptFile, nothing to run - skipping"))
 	}
 
-	if o.verboseFlag || action.ShowOutput {
+	if o.VerboseFlag || action.ShowOutput {
 		return o.executeInstructionActionVerboseFunc(o, action, scriptOutputPath)
 	} else {
 		return o.executeInstructionActionFunc(o, action, scriptOutputPath)

--- a/internal/cmd/anchor/dynamic/runner/runner_test.go
+++ b/internal/cmd/anchor/dynamic/runner/runner_test.go
@@ -437,7 +437,7 @@ var ActionExecVerboseFailToExecScript = func(t *testing.T) {
 			action1.ScriptFile = ""
 
 			fakeO := NewOrchestrator(stubs.CommandFolder1Name)
-			fakeO.verboseFlag = true
+			fakeO.VerboseFlag = true
 			fakeO.s = fakeShell
 			fakeO.prntr = fakePrinter
 
@@ -686,7 +686,7 @@ var RunInstructionActionFailToExecuteAction = func(t *testing.T) {
 			action1 := models.GetInstructionActionById(instRootTestData.Instructions, stubs.CommandFolder1Item1Action1Id)
 
 			fakeO := NewOrchestrator(stubs.CommandFolder1Name)
-			fakeO.verboseFlag = true
+			fakeO.VerboseFlag = true
 
 			execActionVerboseCallCount := 0
 			fakeO.executeInstructionActionVerboseFunc = func(o *ActionRunnerOrchestrator, action *models.Action, scriptOutputPath string) *errors.PromptError {
@@ -711,7 +711,7 @@ var RunInstructionActionFailToExecuteVerboseAction = func(t *testing.T) {
 			action1 := models.GetInstructionActionById(instRootTestData.Instructions, stubs.CommandFolder1Item1Action1Id)
 
 			fakeO := NewOrchestrator(stubs.CommandFolder1Name)
-			fakeO.verboseFlag = false
+			fakeO.VerboseFlag = false
 
 			execActionCallCount := 0
 			fakeO.executeInstructionActionFunc = func(o *ActionRunnerOrchestrator, action *models.Action, scriptOutputPath string) *errors.PromptError {
@@ -736,7 +736,7 @@ var RunInstructionActionRunActionWithVerboseFromFlag = func(t *testing.T) {
 			action1 := models.GetInstructionActionById(instRootTestData.Instructions, stubs.CommandFolder1Item1Action1Id)
 
 			fakeO := NewOrchestrator(stubs.CommandFolder1Name)
-			fakeO.verboseFlag = true
+			fakeO.VerboseFlag = true
 			execActionVerboseCallCount := 0
 			fakeO.executeInstructionActionVerboseFunc = func(o *ActionRunnerOrchestrator, action *models.Action, scriptOutputPath string) *errors.PromptError {
 				execActionVerboseCallCount++
@@ -757,10 +757,11 @@ var RunInstructionActionRunActionWithForcedVerboseFromSchema = func(t *testing.T
 		with.Logging(ctx, t, func(logger logger.Logger) {
 			instRootTestData := stubs.GenerateInstructionsTestData()
 			action1 := models.GetInstructionActionById(instRootTestData.Instructions, stubs.CommandFolder1Item1Action1Id)
+			// showOutput is the verbose way without using the --verbose flag
 			action1.ShowOutput = true
 
 			fakeO := NewOrchestrator(stubs.CommandFolder1Name)
-			fakeO.verboseFlag = false
+			fakeO.VerboseFlag = false
 			execActionVerboseCallCount := 0
 			fakeO.executeInstructionActionVerboseFunc = func(o *ActionRunnerOrchestrator, action *models.Action, scriptOutputPath string) *errors.PromptError {
 				execActionVerboseCallCount++
@@ -783,7 +784,7 @@ var RunInstructionActionRunActionInteractive = func(t *testing.T) {
 			action1 := models.GetInstructionActionById(instRootTestData.Instructions, stubs.CommandFolder1Item1Action1Id)
 
 			fakeO := NewOrchestrator(stubs.CommandFolder1Name)
-			fakeO.verboseFlag = false
+			fakeO.VerboseFlag = false
 			execActionCallCount := 0
 			fakeO.executeInstructionActionFunc = func(o *ActionRunnerOrchestrator, action *models.Action, scriptOutputPath string) *errors.PromptError {
 				execActionCallCount++
@@ -908,10 +909,6 @@ var ExtractMultipleQuotedArgsFromActionScriptFileAttribute = func(t *testing.T) 
 	assert.NotEmpty(t, cmd)
 	assert.Equal(t, "/path/to/script", cmd)
 	assert.Len(t, args, 4)
-	//fmt.Printf("ZACHI")
-	//for i, item := range args {
-	//	fmt.Printf("%v. %s ", i, item)
-	//}
 	assert.Equal(t, "${PWD}", args[0])
 	assert.Equal(t, "\"this is one argument\"", args[1])
 	assert.Equal(t, "\"second argument\"", args[2])

--- a/internal/common/context.go
+++ b/internal/common/context.go
@@ -31,7 +31,8 @@ type NonCmdScopedFlagsSetter interface {
 }
 
 type NonCmdScopedFlags struct {
-	NoAutoUpdate bool
+	NoAutoUpdate   bool
+	NoAnchorOutput bool
 }
 
 type anchorContext struct {
@@ -96,7 +97,8 @@ func EmptyAnchorContext(reg *registry.InjectionsRegistry) Context {
 		registry:  reg,
 		nonCmdScopedFlags: NonCmdScopedFlags{
 			// Default values
-			NoAutoUpdate: false,
+			NoAutoUpdate:   false,
+			NoAnchorOutput: false,
 		},
 	}
 }

--- a/internal/globals/consts.go
+++ b/internal/globals/consts.go
@@ -1,9 +1,10 @@
 package globals
 
 const (
-	CLIRootCommandName    string = "anchor"
-	VerboseFlagName       string = "verbose"
-	NoAutoUpdateFlagName  string = "no-auto-update"
-	InstructionsFileName  string = "instructions.yaml"
-	AnchorCommandFileName string = "command.yaml"
+	CLIRootCommandName     string = "anchor"
+	VerboseFlagName        string = "verbose"
+	NoAutoUpdateFlagName   string = "--no-auto-update"
+	NoAnchorOutputFlagName string = "--no-anchor-output"
+	InstructionsFileName   string = "instructions.yaml"
+	AnchorCommandFileName  string = "command.yaml"
 )

--- a/pkg/printer/plainer.go
+++ b/pkg/printer/plainer.go
@@ -18,12 +18,20 @@ type printerPlainerImpl struct {
 	failureMsgFormat string
 }
 
+type printerPlainerNoOpImpl struct {
+	PrinterPlainer
+}
+
 func NewPlainer(runMsg string, successMsg string, failureMsg string) PrinterPlainer {
 	return &printerPlainerImpl{
 		runMsg:           runMsg,
 		successMsg:       successMsg,
 		failureMsgFormat: failureMsg,
 	}
+}
+
+func NewNoOpPlainer() PrinterPlainer {
+	return &printerPlainerNoOpImpl{}
 }
 
 func (p *printerPlainerImpl) Start() {
@@ -38,4 +46,13 @@ func (p *printerPlainerImpl) StopOnSuccess() {
 func (p *printerPlainerImpl) StopOnFailure(err error) {
 	//_, _ = fmt.Fprintf(os.Stdout, "\r \r")
 	fmt.Printf(fmt.Sprintf(p.failureMsgFormat, err.Error()))
+}
+
+func (p *printerPlainerNoOpImpl) Start() {
+}
+
+func (p *printerPlainerNoOpImpl) StopOnSuccess() {
+}
+
+func (p *printerPlainerNoOpImpl) StopOnFailure(err error) {
 }

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -39,13 +39,19 @@ type ConfigViewTemplateItem struct {
 
 type printerImpl struct {
 	Printer
+	noAnchorOutput bool
 }
 
-func New() Printer {
-	return &printerImpl{}
+func New(noAnchorOutput bool) Printer {
+	return &printerImpl{
+		noAnchorOutput: noAnchorOutput,
+	}
 }
 
 func (p *printerImpl) PrintEmptyLines(count int) {
+	if p.noAnchorOutput {
+		return
+	}
 	for i := 0; i < count; i++ {
 		fmt.Println()
 	}
@@ -101,6 +107,9 @@ func (p *printerImpl) PrintMissingInstructions() {
 }
 
 func (p *printerImpl) PrintSuccess(message string) {
+	if p.noAnchorOutput {
+		return
+	}
 	fmt.Printf("%s %s", promptui.IconGood, message)
 	fmt.Println()
 }
@@ -116,6 +125,9 @@ func (p *printerImpl) PrintError(message string) {
 }
 
 func (p *printerImpl) PrepareRunActionPlainer(actionId string) PrinterPlainer {
+	if p.noAnchorOutput {
+		return NewNoOpPlainer()
+	}
 	return NewPlainer(
 		getPlainerRunActionMessage(actionId),
 		getPlainerSuccessActionMessage(actionId),
@@ -123,6 +135,9 @@ func (p *printerImpl) PrepareRunActionPlainer(actionId string) PrinterPlainer {
 }
 
 func (p *printerImpl) PrepareRunActionSpinner(actionId string, scriptOutputPath string) PrinterSpinner {
+	if p.noAnchorOutput {
+		return NewNoOpSpinner()
+	}
 	return NewSpinner(
 		getSpinnerRunActionMessage(actionId),
 		getSpinnerSuccessActionMessage(actionId),
@@ -130,6 +145,9 @@ func (p *printerImpl) PrepareRunActionSpinner(actionId string, scriptOutputPath 
 }
 
 func (p *printerImpl) PrepareReadRemoteHeadCommitHashSpinner(url string, branch string) PrinterSpinner {
+	if p.noAnchorOutput {
+		return NewNoOpSpinner()
+	}
 	return NewSpinner(
 		getSpinnerReadRemoteHeadCommitHashMessage(url, branch),
 		getSpinnerReadRemoteHeadCommitHashSuccessMessage(),
@@ -137,6 +155,9 @@ func (p *printerImpl) PrepareReadRemoteHeadCommitHashSpinner(url string, branch 
 }
 
 func (p *printerImpl) PrepareCloneRepositorySpinner(url string, branch string) PrinterSpinner {
+	if p.noAnchorOutput {
+		return NewNoOpSpinner()
+	}
 	return NewSpinner(
 		getCloneRepositoryMessage(url, branch),
 		getCloneRepositorySuccessMessage(),
@@ -144,6 +165,9 @@ func (p *printerImpl) PrepareCloneRepositorySpinner(url string, branch string) P
 }
 
 func (p *printerImpl) PrepareResetToRevisionSpinner(revision string) PrinterSpinner {
+	if p.noAnchorOutput {
+		return NewNoOpSpinner()
+	}
 	return NewSpinner(
 		getResetToRevisionMessage(revision),
 		getResetToRevisionSuccessMessage(revision),

--- a/pkg/printer/spinner.go
+++ b/pkg/printer/spinner.go
@@ -25,6 +25,10 @@ type printerSpinnerImpl struct {
 	failureMsgFormat string
 }
 
+type printerSpinnerNoOpImpl struct {
+	PrinterSpinner
+}
+
 func NewSpinner(runMsg string, successMsg string, failureMsgFormat string) PrinterSpinner {
 	spnr := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
 	_ = spnr.Color("blue")
@@ -36,6 +40,10 @@ func NewSpinner(runMsg string, successMsg string, failureMsgFormat string) Print
 		successMsg:       successMsg,
 		failureMsgFormat: failureMsgFormat,
 	}
+}
+
+func NewNoOpSpinner() PrinterSpinner {
+	return &printerSpinnerNoOpImpl{}
 }
 
 func (p *printerSpinnerImpl) Spin() {
@@ -69,4 +77,19 @@ func (p *printerSpinnerImpl) StopOnFailureWithCustomMessage(message string) {
 	_, _ = fmt.Fprintf(os.Stdout, "\r \r")
 	fmt.Printf("%s %s", promptui.IconBad, message)
 	fmt.Println()
+}
+
+func (p *printerSpinnerNoOpImpl) Spin() {
+}
+
+func (p *printerSpinnerNoOpImpl) StopOnSuccess() {
+}
+
+func (p *printerSpinnerNoOpImpl) StopOnSuccessWithCustomMessage(message string) {
+}
+
+func (p *printerSpinnerNoOpImpl) StopOnFailure(err error) {
+}
+
+func (p *printerSpinnerNoOpImpl) StopOnFailureWithCustomMessage(message string) {
 }


### PR DESCRIPTION
[src] Introduced a `--no-anchor-output` flag that allows to hide anchor CLI output upon action run, show only script output
[fix] Verbose flag wasn't properly addresses during action execution
[src] Added a NoOp impl. for printer & spinner